### PR TITLE
release: v0.1.7 — MCP Registry support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-swiss",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-swiss",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-swiss",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Swiss open data MCP server — transport, weather, geodata, companies. Zero API keys.",
   "main": "dist/index.js",
   "bin": {
@@ -60,5 +60,6 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "icon": "assets/icon.svg"
+  "icon": "assets/icon.svg",
+  "mcpName": "io.github.vikramgorla/swiss"
 }

--- a/server.json
+++ b/server.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.vikramgorla/mcp-swiss",
-  "description": "Swiss open data for AI — trains, weather, rivers, maps, and companies. Zero API keys.",
+  "name": "io.github.vikramgorla/swiss",
+  "title": "Swiss Open Data",
+  "description": "Swiss open data MCP server — SBB trains, MeteoSwiss weather, hydrology, Swisstopo geodata, ZEFIX companies. 22 tools, zero API keys.",
   "repository": {
-    "url": "https://github.com/vikramgorla/mcp-swiss.git",
+    "url": "https://github.com/vikramgorla/mcp-swiss",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "0.1.7",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/vikramgorla/mcp-swiss/main/assets/icon.svg",
@@ -22,12 +23,11 @@
     {
       "registryType": "npm",
       "identifier": "mcp-swiss",
-      "version": "0.1.4",
+      "version": "0.1.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
-      },
-      "environmentVariables": []
+      }
     }
   ]
 }


### PR DESCRIPTION
- server.json with official schema
- mcpName in package.json for registry verification
- Ready for mcp-publisher publish after npm release