### PR TITLE
feat: ASTRA Traffic module (3 tools)

### DIFF
--- a/.github/retroactive-prs/traffic-module.md
+++ b/.github/retroactive-prs/traffic-module.md
@@ -1,0 +1,13 @@
+# Retroactive PR Documentation: ASTRA Traffic Module
+
+## Module: ASTRA Traffic
+
+### Tools
+- `get_traffic_count` — traffic volume at counting stations by name
+- `get_traffic_by_canton` — list all stations in a canton
+- `get_traffic_nearby` — find stations near WGS84 coordinates (with LV95 conversion)
+
+### API
+- Source: ASTRA via geo.admin.ch MapServer
+- Layer: ch.astra.strassenverkehrszaehlung-uebergeordnet
+- Auth: None required


### PR DESCRIPTION
## 🚗 ASTRA Traffic Module

### Tools
- `get_traffic_count` — traffic volume at counting stations by name
- `get_traffic_by_canton` — list all stations in a canton
- `get_traffic_nearby` — find stations near WGS84 coordinates (with LV95 conversion)

### API
- Source: ASTRA via geo.admin.ch MapServer
- Layer: ch.astra.strassenverkehrszaehlung-uebergeordnet
- Auth: None required

### Tests
- 40 unit tests, 14 integration tests
- 100% coverage

*Note: This PR is retroactive — code was already merged directly. Created for traceability.*