### PR TITLE
feat: Swiss News / SRF module (2 tools)

### DIFF
--- a/.github/retroactive-prs/news-module.md
+++ b/.github/retroactive-prs/news-module.md
@@ -1,0 +1,12 @@
+# Retroactive PR Documentation: Swiss News Module
+
+## Module: Swiss News / SRF
+
+### Tools
+- `get_swiss_news` — latest headlines by category (switzerland/international/economy)
+- `search_swiss_news` — keyword search across all feeds
+
+### API
+- Source: SRF RSS feeds (srf.ch)
+- Feeds: 1890 (Switzerland), 1922 (International), 1926 (Economy)
+- Auth: None required


### PR DESCRIPTION
## 📺 Swiss News Module

### Tools
- `get_swiss_news` — latest headlines by category (switzerland/international/economy)
- `search_swiss_news` — keyword search across all feeds

### API
- Source: SRF RSS feeds (srf.ch)
- Feeds: 1890 (Switzerland), 1922 (International), 1926 (Economy)
- Auth: None required

### Tests
- 53 unit tests
- 100% coverage
- Pure regex RSS parser, no external deps

*Note: This PR is retroactive — code was already merged directly. Created for traceability.*