### PR TITLE
feat: Hiking Trail Closures module (2 tools)

### DIFF
--- a/.github/retroactive-prs/hiking-module.md
+++ b/.github/retroactive-prs/hiking-module.md
@@ -1,0 +1,12 @@
+# Retroactive PR Documentation: Hiking Trail Closures Module
+
+## Module: Hiking Trail Closures
+
+### Tools
+- `get_trail_closures` — current closures/detours with reason and duration filters
+- `get_trail_closures_nearby` — closures near WGS84 coordinates (with LV95 conversion)
+
+### API
+- Source: ASTRA via geo.admin.ch MapServer
+- Layer: ch.astra.wanderland-sperrungen_umleitungen
+- Auth: None required


### PR DESCRIPTION
## 🥾 Hiking Trail Closures Module

### Tools
- `get_trail_closures` — current closures/detours with reason and duration filters
- `get_trail_closures_nearby` — closures near WGS84 coordinates (with LV95 conversion)

### API
- Source: ASTRA via geo.admin.ch MapServer
- Layer: ch.astra.wanderland-sperrungen_umleitungen
- Auth: None required

### Tests
- 53 unit tests, 18 integration tests
- Deduplication across parallel API calls
- 100% coverage

*Note: This PR is retroactive — code was already merged directly. Created for traceability.*