### PR TITLE
fix: shorten server.json description for MCP registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vikramgorla/swiss",
   "title": "Switzerland MCP 🇨🇭",
-  "description": "Swiss open data — 65 tools, zero API keys. Trains, weather, geodata, energy, statistics, SNB rates, recycling, news, voting, dams, hiking, real estate, traffic.",
+  "description": "Swiss open data MCP server. 65 tools, zero API keys. Transport, weather, geodata, news, rates.",
   "repository": {
     "url": "https://github.com/vikramgorla/mcp-swiss",
     "source": "github"


### PR DESCRIPTION
Fixes MCP registry 422 error: description must be ≤100 chars. Shortened from 160 to 94 chars.