### PR TITLE
feat: integrate earthquake module — 3 tools (65 → 68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 `mcp-swiss` is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives any AI assistant direct access to Swiss open data — trains, weather, rivers, maps, and companies.
 
-**65 tools. No API keys. No registration. No server to run. Just `npx mcp-swiss`.**
+**68 tools. No API keys. No registration. No server to run. Just `npx mcp-swiss`.**
 
 ```
 🚆 Transport    — SBB, PostBus, trams, live departures, journey planning
@@ -42,6 +42,7 @@
 🥾 Hiking       — Swiss trail closures and hiking alerts (swisstopo)
 🏠 Real Estate  — Swiss property prices, rent index, housing data (BFS)
 🚗 Traffic      — ASTRA counting stations, daily volumes
+🌍 Earthquakes  — Swiss Seismological Service (SED/ETH Zürich), FDSN API
 ```
 
 ---
@@ -252,7 +253,7 @@ Once connected, try asking your AI:
 
 ## Tools
 
-> 65 tools across 19 modules. Full specifications: [`docs/tool-specs.md`](docs/tool-specs.md) · Machine-readable: [`docs/tools.schema.json`](docs/tools.schema.json)
+> 68 tools across 20 modules. Full specifications: [`docs/tool-specs.md`](docs/tool-specs.md) · Machine-readable: [`docs/tools.schema.json`](docs/tools.schema.json)
 
 ### 🚆 Transport (5 tools)
 
@@ -413,6 +414,14 @@ Once connected, try asking your AI:
 | `get_traffic_count` | Traffic counting station data (ASTRA) — daily volumes and heavy traffic share |
 | `get_traffic_by_canton` | List ASTRA traffic counting stations filtered by canton |
 | `get_traffic_nearby` | Find traffic counting stations near given coordinates |
+
+### 🌍 Earthquakes / SED (3 tools)
+
+| Tool | Description |
+|------|-------------|
+| `get_recent_earthquakes` | Recent seismic events in/around Switzerland from the Swiss Seismological Service (SED) at ETH Zürich |
+| `get_earthquake_details` | Full details for a specific seismic event by SED event ID |
+| `search_earthquakes_by_location` | Earthquakes near given coordinates with configurable radius, time range, and limit |
 
 ---
 

--- a/docs/tool-specs.md
+++ b/docs/tool-specs.md
@@ -2208,5 +2208,53 @@ Find ASTRA traffic counting stations near given coordinates.
 
 ---
 
-*Specification generated from mcp-swiss v0.3.2-dev source code.*  
-*API sources: transport.opendata.ch, api.existenz.ch, api3.geo.admin.ch, zefix.admin.ch, openholidaysapi.org, ws.parlament.ch, aws.slf.ch/whiterisk.ch, geo.admin.ch (NABEL), service.post.ch, strompreis.elcom.admin.ch, pxweb.bfs.admin.ch, opendata.swiss, data.snb.ch, openerz.metaodi.ch, srf.ch, data.bs.ch, geo.admin.ch (SFOE dams), geo.admin.ch (hiking), api3.geo.admin.ch (ASTRA traffic)*
+---
+
+## Earthquakes
+
+### `get_recent_earthquakes`
+
+Recent seismic events in and around Switzerland from the Swiss Seismological Service (SED) at ETH Zürich.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| days | number | ❌ | Number of past days to search (default: 30, max: 365) |
+| min_magnitude | number | ❌ | Minimum magnitude filter (default: 0.5) |
+| limit | number | ❌ | Maximum number of results (default: 20) |
+| include_blasts | boolean | ❌ | Include quarry blasts (default: false) |
+
+---
+
+### `get_earthquake_details`
+
+Full details for a specific seismic event by SED event ID.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| event_id | string | ✅ | SED event ID (e.g. 'smi:ch.ethz.sed/sc25a/Event/2026errxzt') |
+
+---
+
+### `search_earthquakes_by_location`
+
+Search for earthquakes near given coordinates using the SED FDSN API.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| lat | number | ✅ | Latitude of center point (decimal degrees) |
+| lon | number | ✅ | Longitude of center point (decimal degrees) |
+| radius_km | number | ❌ | Search radius in kilometres (default: 50, max: 500) |
+| days | number | ❌ | Number of past days to search (default: 90, max: 365) |
+| min_magnitude | number | ❌ | Minimum magnitude filter (default: 0.5) |
+| limit | number | ❌ | Maximum number of results (default: 20, max: 100) |
+
+---
+
+*Specification generated from mcp-swiss v0.4.1 source code.*  
+*API sources: transport.opendata.ch, api.existenz.ch, api3.geo.admin.ch, zefix.admin.ch, openholidaysapi.org, ws.parlament.ch, aws.slf.ch/whiterisk.ch, geo.admin.ch (NABEL), service.post.ch, strompreis.elcom.admin.ch, pxweb.bfs.admin.ch, opendata.swiss, data.snb.ch, openerz.metaodi.ch, srf.ch, data.bs.ch, geo.admin.ch (SFOE dams), geo.admin.ch (hiking), api3.geo.admin.ch (ASTRA traffic), arclink.ethz.ch (SED earthquakes)*

--- a/docs/tools.schema.json
+++ b/docs/tools.schema.json
@@ -1390,6 +1390,55 @@
         }
       },
       "outputExample": [{ "id": "A1-ZH-001", "name": "Zürich Nord", "distance_m": 1200 }]
+    },
+    {
+      "name": "get_recent_earthquakes",
+      "module": "earthquakes",
+      "description": "Recent seismic events in and around Switzerland from the Swiss Seismological Service (SED) at ETH Zürich",
+      "apiSource": "http://arclink.ethz.ch/fdsnws/event/1/",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "days": { "type": "number" },
+          "min_magnitude": { "type": "number" },
+          "limit": { "type": "number" },
+          "include_blasts": { "type": "boolean" }
+        }
+      },
+      "outputExample": { "count": 5, "events": [{ "event_id": "smi:ch.ethz.sed/...", "magnitude": 2.1 }] }
+    },
+    {
+      "name": "get_earthquake_details",
+      "module": "earthquakes",
+      "description": "Full details for a specific seismic event by SED event ID",
+      "apiSource": "http://arclink.ethz.ch/fdsnws/event/1/",
+      "inputSchema": {
+        "type": "object",
+        "required": ["event_id"],
+        "properties": {
+          "event_id": { "type": "string" }
+        }
+      },
+      "outputExample": { "event": { "event_id": "smi:ch.ethz.sed/...", "magnitude": 3.4, "location": "Valais" } }
+    },
+    {
+      "name": "search_earthquakes_by_location",
+      "module": "earthquakes",
+      "description": "Search for earthquakes near given coordinates using the SED FDSN API",
+      "apiSource": "http://arclink.ethz.ch/fdsnws/event/1/",
+      "inputSchema": {
+        "type": "object",
+        "required": ["lat", "lon"],
+        "properties": {
+          "lat": { "type": "number" },
+          "lon": { "type": "number" },
+          "radius_km": { "type": "number" },
+          "days": { "type": "number" },
+          "min_magnitude": { "type": "number" },
+          "limit": { "type": "number" }
+        }
+      },
+      "outputExample": { "count": 3, "center": { "lat": 46.948, "lon": 7.447 }, "radius_km": 50, "events": [] }
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vikramgorla/swiss",
   "title": "Switzerland MCP 🇨🇭",
-  "description": "Swiss open data MCP server. 65 tools, zero API keys. Transport, weather, geodata, news, rates.",
+  "description": "Swiss open data MCP server. 68 tools, zero API keys. Transport, weather, geodata, news, rates.",
   "repository": {
     "url": "https://github.com/vikramgorla/mcp-swiss",
     "source": "github"

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { damsTools, handleDams } from "./modules/dams.js";
 import { hikingTools, handleHiking } from "./modules/hiking.js";
 import { realEstateTools, handleRealEstate } from "./modules/realestate.js";
 import { trafficTools, handleTraffic } from "./modules/traffic.js";
+import { earthquakeTools, handleEarthquakes } from "./modules/earthquakes.js";
 
 const server = new Server(
   { name: "mcp-swiss", version: "0.1.0" },
@@ -51,6 +52,7 @@ const allTools = [
   ...hikingTools,
   ...realEstateTools,
   ...trafficTools,
+  ...earthquakeTools,
 ];
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -102,6 +104,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       result = await handleRealEstate(name, safeArgs);
     } else if (trafficTools.some((t) => t.name === name)) {
       result = await handleTraffic(name, safeArgs);
+    } else if (earthquakeTools.some((t) => t.name === name)) {
+      result = await handleEarthquakes(name, safeArgs as Record<string, string | number | boolean>);
     } else {
       throw new Error(`Unknown tool: ${name}`);
     }

--- a/tests/mcp/protocol.test.ts
+++ b/tests/mcp/protocol.test.ts
@@ -120,7 +120,7 @@ describe('MCP protocol: tools/list', () => {
     expect(Array.isArray(result.tools)).toBe(true);
   });
 
-  it('returns exactly 65 tools', async () => {
+  it('returns exactly 68 tools', async () => {
     const response = await sendMcpRequest({
       jsonrpc: '2.0',
       id: 3,
@@ -128,7 +128,7 @@ describe('MCP protocol: tools/list', () => {
     });
 
     const result = response.result as { tools: Tool[] };
-    expect(result.tools).toHaveLength(65);
+    expect(result.tools).toHaveLength(68);
   });
 
   it('each tool has name, description, inputSchema', async () => {


### PR DESCRIPTION
## Integration

- Wire earthquake module into index.ts
- Update protocol test count: 65 → 68
- Update README, server.json, tool-specs, tools.schema.json
- Add npm 'already published' guard to release.yml

### New tools
- `get_recent_earthquakes` — recent seismic events
- `get_earthquake_details` — event details by ID
- `search_earthquakes_by_location` — earthquakes near coordinates

### Source
Swiss Seismological Service (SED) at ETH Zürich — FDSN API, zero auth