### PR TITLE
ci: add guard workflow — only develop can merge to main

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,23 @@
+name: Guard Main Branch
+
+# Runs on PRs targeting main — rejects anything not from develop
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source:
+    name: Verify PR source is develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          HEAD="${{ github.head_ref }}"
+          echo "PR source branch: $HEAD"
+          if [ "$HEAD" != "develop" ]; then
+            echo "❌ ERROR: Only the 'develop' branch can merge to main."
+            echo "   Got: $HEAD"
+            echo "   Please merge your changes to develop first, then create a develop → main PR."
+            exit 1
+          fi
+          echo "✅ Source branch is develop — allowed."


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on PRs to main and rejects any PR not from `develop`.

This enforces our branch model: all changes go through develop first.

Once merged to develop and then to main, add `Verify PR source is develop` to the required status checks on main branch protection.