### PR TITLE
ci: auto-trigger Docker + MCPB builds from release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,3 +81,12 @@ jobs:
             org.opencontainers.image.description=Swiss open data MCP server — 68 tools, zero API keys
             org.opencontainers.image.source=https://github.com/vikramgorla/mcp-swiss
             org.opencontainers.image.licenses=MIT
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: vikramgorla/mcp-swiss
+          short-description: "Swiss open data MCP server — 68 tools, 20 modules, zero API keys"
+          readme-filepath: ./README.md

--- a/.github/workflows/mcpb.yml
+++ b/.github/workflows/mcpb.yml
@@ -65,19 +65,12 @@ jobs:
           echo "BUNDLE_SIZE=$(du -h "${GITHUB_WORKSPACE}/mcp-swiss-${VERSION}.mcpb" | cut -f1)" >> $GITHUB_ENV
 
       - name: Upload to GitHub Release
-        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.version.outputs.version }}
           files: |
             mcp-swiss-${{ steps.version.outputs.version }}.mcpb
             mcp-swiss.mcpb
-
-      - name: Upload artifact (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: mcpb-bundle
-          path: ${{ env.BUNDLE_PATH }}
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,24 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
 
+      - name: Trigger Docker build
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Triggering Docker build for v${VERSION}..."
+          gh workflow run docker.yml --ref main -f version="${VERSION}" || echo "Docker workflow trigger failed (non-fatal)"
+
+      - name: Trigger MCPB build
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Triggering MCPB build for v${VERSION}..."
+          gh workflow run mcpb.yml --ref main -f version="${VERSION}" || echo "MCPB workflow trigger failed (non-fatal)"
+
       - name: Publish to npm
         run: |
           VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Problem
Releases created by github-actions[bot] don't fire `release: [published]` events, so Docker and MCPB workflows never auto-trigger.

## Solution
- release.yml now calls `gh workflow run docker.yml` and `gh workflow run mcpb.yml` after creating the GitHub Release
- mcpb.yml updated to upload to the release (not artifacts) when triggered by workflow_dispatch
- docker.yml now auto-updates Docker Hub description from README

## Result
Full release pipeline is now fully automated: npm → GitHub Release → Docker Hub + GHCR → .mcpb bundle — all from a single merge to main.

## Note
Docker Hub description update via API (Part 2) failed — the PAT `dckr_pat_*` lacks the 'Account management' scope needed for the Docker Hub v2 PATCH endpoint. The `peter-evans/dockerhub-description` action in CI should work if the `DOCKERHUB_TOKEN` secret has the right scope. If not, Vik may need to regenerate the PAT with 'Read & Write' account management permissions.