### PR TITLE
fix(security): bump hono 4.12.5 → 4.12.7 (prototype pollution)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Security Fix
Fixes Dependabot alert #1 — medium severity prototype pollution in hono parseBody.

**Package:** hono (transitive via @modelcontextprotocol/sdk)
**From:** 4.12.5 → **To:** 4.12.7
**Advisory:** Prototype pollution via `__proto__` key in `parseBody({ dot: true })`

Only package-lock.json changes — the SDK's semver range `^4.11.4` already allows 4.12.7.