### PR TITLE
release: v0.5.7 — security fix (hono prototype pollution)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mcp-swiss",
   "display_name": "Switzerland MCP 🇨🇭",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Swiss open data for AI — 68 tools, zero API keys. Transport, weather, geodata, companies, parliament, and 15 more modules.",
   "long_description": "mcp-swiss gives any AI assistant direct access to Swiss open data. 68 tools across 20 modules: train schedules (SBB), weather (MeteoSwiss), river levels (BAFU), geodata (swisstopo), company registry (ZEFIX), parliament, avalanche bulletins, holidays, postal services, electricity prices, population statistics, exchange rates (SNB), recycling schedules, news (SRF), voting results, dam registry, hiking trail alerts, real estate data, traffic counts, and earthquake monitoring. All APIs are free and require zero authentication.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-swiss",
-  "version": "0.5.7-dev",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-swiss",
-      "version": "0.5.7-dev",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-swiss",
-  "version": "0.5.7-dev",
+  "version": "0.5.7",
   "description": "Swiss open data MCP server — 68 tools across 20 modules. Zero API keys.",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/vikramgorla/mcp-swiss",
     "source": "github"
   },
-  "version": "0.5.7-dev",
+  "version": "0.5.7",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/vikramgorla/mcp-swiss/main/assets/icon.svg",
@@ -25,7 +25,7 @@
     {
       "registryType": "npm",
       "identifier": "mcp-swiss",
-      "version": "0.5.7-dev",
+      "version": "0.5.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release v0.5.7

Security patch release.

### Changes
- Bumped hono from 4.12.5 → 4.12.7 (transitive via @modelcontextprotocol/sdk)
- Fixes medium-severity Dependabot alert #1: prototype pollution via `parseBody({ dot: true })`

### Checklist
- [x] lint + build + unit tests pass
- [x] package.json, package-lock.json, server.json, manifest.json bumped to 0.5.7
- [x] Security fix verified (hono@4.12.7 in npm ls)