### PR TITLE
feat: add SLF snow conditions module — live snow depth from 307 Alpine stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 `mcp-swiss` is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives any AI assistant direct access to Swiss open data — trains, weather, rivers, maps, and companies.
 
-**73 tools. No API keys. No registration. No server to run. Just `npx mcp-swiss`.**
+**76 tools. No API keys. No registration. No server to run. Just `npx mcp-swiss`.**
 
 ```
 🚆 Transport    — SBB, PostBus, trams, live departures, journey planning
@@ -280,7 +280,7 @@ docker pull ghcr.io/vikramgorla/mcp-swiss
 
 ## Module Filtering
 
-By default, mcp-swiss loads all 20 modules (73 tools). For better token efficiency, load only the modules you need:
+By default, mcp-swiss loads all 21 modules (76 tools). For better token efficiency, load only the modules you need:
 
 ### Select specific modules
 ```json
@@ -309,11 +309,11 @@ By default, mcp-swiss loads all 20 modules (73 tools). For better token efficien
 | Preset | Modules | Tools | Token Savings |
 |--------|---------|-------|---------------|
 | `commuter` | transport, weather, holidays | 14 | 81% |
-| `outdoor` | weather, avalanche, hiking, earthquakes, dams | 16 | 78% |
+| `outdoor` | weather, avalanche, hiking, earthquakes, dams, snow | 19 | 75% |
 | `business` | companies, geodata, post, energy, statistics, snb | 24 | 67% |
 | `citizen` | parliament, voting, holidays, news | 17 | 77% |
 | `minimal` | transport | 5 | 93% |
-| `full` | all 20 modules (default) | 73 | — |
+| `full` | all 21 modules (default) | 76 | — |
 
 Combine preset + modules: `--preset commuter --modules parliament`
 
@@ -347,7 +347,7 @@ Once connected, try asking your AI:
 
 ## Tools
 
-> 73 tools across 20 modules. Full specifications: [`docs/tool-specs.md`](docs/tool-specs.md) · Machine-readable: [`docs/tools.schema.json`](docs/tools.schema.json)
+> 76 tools across 21 modules. Full specifications: [`docs/tool-specs.md`](docs/tool-specs.md) · Machine-readable: [`docs/tools.schema.json`](docs/tools.schema.json)
 
 ### 🚆 Transport (5 tools)
 
@@ -522,6 +522,14 @@ Once connected, try asking your AI:
 | `get_earthquake_details` | Full details for a specific seismic event by SED event ID |
 | `search_earthquakes_by_location` | Earthquakes near given coordinates with configurable radius, time range, and limit |
 
+### ❄️ Snow Conditions / SLF (3 tools)
+
+| Tool | Description |
+|------|-------------|
+| `get_snow_conditions` | Current snow depth and new snow (24h) across Switzerland from SLF IMIS stations, filterable by canton/altitude |
+| `list_snow_stations` | All 307 SLF snow measurement stations (IMIS automatic + manual study plots) |
+| `get_snow_measurements` | Detailed snow and weather measurements for a specific SLF station |
+
 ---
 
 ## Data Sources
@@ -550,6 +558,7 @@ All official Swiss open data — no API keys required:
 | [pxweb.bfs.admin.ch](https://www.pxweb.bfs.admin.ch) | BFS property prices + rent index | [BFS housing](https://www.bfs.admin.ch/bfs/en/home/statistics/construction-housing.html) |
 | [geo.admin.ch](https://api3.geo.admin.ch) — ASTRA | Traffic counting stations + daily volumes | [ASTRA](https://www.astra.admin.ch) |
 | [arclink.ethz.ch](http://arclink.ethz.ch) | Swiss Seismological Service earthquakes (SED/ETH) | [SED](http://www.seismo.ethz.ch) |
+| [measurement-api.slf.ch](https://measurement-api.slf.ch/public/api) | SLF snow depth + measurements (IMIS + study plots, CC BY 4.0) | [SLF](https://www.slf.ch) |
 
 ---
 

--- a/docs/tool-specs.md
+++ b/docs/tool-specs.md
@@ -29,6 +29,7 @@
 - [Real Estate Module (3 tools)](#real-estate)
 - [Traffic / ASTRA Module (3 tools)](#traffic)
 - [Earthquakes / SED Module (3 tools)](#earthquakes)
+- [Snow Conditions / SLF Module (3 tools)](#snow-conditions)
 
 ---
 
@@ -2468,5 +2469,50 @@ Search for earthquakes near given coordinates using the SED FDSN API.
 
 ---
 
+---
+
+## Snow Conditions
+
+### `get_snow_conditions`
+
+Get current snow conditions across Switzerland from SLF (WSL Institute for Snow and Avalanche Research). Returns snow depth and new snow (24h) for IMIS stations, sorted by snow depth. Data updated daily.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| canton | string | ❌ | Filter by canton abbreviation (e.g. GR, VS, BE, UR, TI) |
+| min_altitude | number | ❌ | Minimum station altitude in metres (e.g. 2000) |
+| limit | number | ❌ | Maximum number of stations to return (default: 20, max: 100) |
+
+---
+
+### `list_snow_stations`
+
+List all SLF snow measurement stations in Switzerland (IMIS automatic stations and manual study plots). Returns station code, name, altitude, canton, and type. Sorted by elevation descending.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| canton | string | ❌ | Filter by canton abbreviation (e.g. GR, VS, BE) |
+| type | string | ❌ | Station type: "imis" (automatic) or "study-plot" (manual). Returns both by default |
+| limit | number | ❌ | Maximum number of stations to return (default: 20, max: 200) |
+
+---
+
+### `get_snow_measurements`
+
+Get detailed snow and weather measurements for a specific SLF station. IMIS stations return 30-min data (snow depth, temperature, humidity, wind, radiation). Study plots return daily data (snow depth, new snow, water equivalent).
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| station_code | string | ✅ | Station code (e.g. DAV2, WFJ2, 4AO0). Use list_snow_stations to find codes |
+| type | string | ❌ | Station type: "imis" (default) or "study-plot". Determines which API endpoint to query |
+
+---
+
 *Specification generated from mcp-swiss source code.*  
-*API sources: transport.opendata.ch, api.existenz.ch, api3.geo.admin.ch, zefix.admin.ch, openholidaysapi.org, ws.parlament.ch, aws.slf.ch/whiterisk.ch, geo.admin.ch (NABEL), service.post.ch, strompreis.elcom.admin.ch, pxweb.bfs.admin.ch, opendata.swiss, data.snb.ch, openerz.metaodi.ch, srf.ch, data.bs.ch, geo.admin.ch (SFOE dams), geo.admin.ch (hiking), api3.geo.admin.ch (ASTRA traffic), arclink.ethz.ch (SED earthquakes)*
+*API sources: transport.opendata.ch, api.existenz.ch, api3.geo.admin.ch, zefix.admin.ch, openholidaysapi.org, ws.parlament.ch, aws.slf.ch/whiterisk.ch, geo.admin.ch (NABEL), service.post.ch, strompreis.elcom.admin.ch, pxweb.bfs.admin.ch, opendata.swiss, data.snb.ch, openerz.metaodi.ch, srf.ch, data.bs.ch, geo.admin.ch (SFOE dams), geo.admin.ch (hiking), api3.geo.admin.ch (ASTRA traffic), arclink.ethz.ch (SED earthquakes), measurement-api.slf.ch (SLF snow)*

--- a/docs/tools.schema.json
+++ b/docs/tools.schema.json
@@ -1439,6 +1439,51 @@
         }
       },
       "outputExample": { "count": 3, "center": { "lat": 46.948, "lon": 7.447 }, "radius_km": 50, "events": [] }
+    },
+    {
+      "name": "get_snow_conditions",
+      "module": "snow",
+      "description": "Get current snow conditions across Switzerland from SLF (WSL Institute for Snow and Avalanche Research)",
+      "apiSource": "https://measurement-api.slf.ch/public/api",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "canton": { "type": "string" },
+          "min_altitude": { "type": "number" },
+          "limit": { "type": "number" }
+        }
+      },
+      "outputExample": { "count": 20, "stations": [{ "station": "Zermatt", "altitude_m": 3150, "canton": "VS", "snow_depth_cm": 245, "new_snow_24h_cm": 32 }] }
+    },
+    {
+      "name": "list_snow_stations",
+      "module": "snow",
+      "description": "List all SLF snow measurement stations in Switzerland (IMIS automatic + manual study plots)",
+      "apiSource": "https://measurement-api.slf.ch/public/api",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "canton": { "type": "string" },
+          "type": { "type": "string", "enum": ["imis", "study-plot"] },
+          "limit": { "type": "number" }
+        }
+      },
+      "outputExample": { "count": 20, "total_stations": 307, "stations": [{ "code": "DAV2", "name": "Bärentälli", "altitude_m": 2558, "canton": "GR", "type": "imis" }] }
+    },
+    {
+      "name": "get_snow_measurements",
+      "module": "snow",
+      "description": "Detailed snow and weather measurements for a specific SLF station",
+      "apiSource": "https://measurement-api.slf.ch/public/api",
+      "inputSchema": {
+        "type": "object",
+        "required": ["station_code"],
+        "properties": {
+          "station_code": { "type": "string" },
+          "type": { "type": "string", "enum": ["imis", "study-plot"] }
+        }
+      },
+      "outputExample": { "station_code": "DAV2", "type": "imis", "measurements": [{ "time": "2026-03-15T08:30:00Z", "snow_depth_cm": 139, "air_temp_c": -6.8 }] }
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "name": "mcp-swiss",
   "display_name": "Switzerland MCP \ud83c\udde8\ud83c\udded",
   "version": "0.6.0",
-  "description": "Swiss open data for AI \u2014 73 tools, zero API keys. Transport, weather, geodata, companies, parliament, and 15 more modules.",
-  "long_description": "mcp-swiss gives any AI assistant direct access to Swiss open data. 73 tools across 20 modules: train schedules (SBB), weather (MeteoSwiss), river levels (BAFU), geodata (swisstopo), company registry (ZEFIX), parliament (OpenParlData.ch), avalanche bulletins, holidays, postal services, electricity prices, population statistics, exchange rates (SNB), recycling schedules, news (SRF), voting results, dam registry, hiking trail alerts, real estate data, traffic counts, and earthquake monitoring. All APIs are free and require zero authentication.",
+  "description": "Swiss open data for AI \u2014 76 tools, zero API keys. Transport, weather, geodata, companies, parliament, and 16 more modules.",
+  "long_description": "mcp-swiss gives any AI assistant direct access to Swiss open data. 76 tools across 21 modules: train schedules (SBB), weather (MeteoSwiss), river levels (BAFU), geodata (swisstopo), company registry (ZEFIX), parliament (OpenParlData.ch), avalanche bulletins, holidays, postal services, electricity prices, population statistics, exchange rates (SNB), recycling schedules, news (SRF), voting results, dam registry, hiking trail alerts, real estate data, traffic counts, earthquake monitoring, and snow conditions (SLF). All APIs are free and require zero authentication.",
   "author": {
     "name": "Vikram Gorla",
     "url": "https://github.com/vikramgorla"
@@ -301,6 +301,18 @@
       "description": "Search earthquakes near a location"
     },
     {
+      "name": "get_snow_conditions",
+      "description": "Get current snow conditions across Switzerland from SLF"
+    },
+    {
+      "name": "list_snow_stations",
+      "description": "List all SLF snow measurement stations"
+    },
+    {
+      "name": "get_snow_measurements",
+      "description": "Get detailed measurements for a specific SLF station"
+    },
+    {
       "name": "search_parliament_speeches",
       "description": "Search speeches given in Swiss parliament"
     },
@@ -347,7 +359,8 @@
     "hiking",
     "real-estate",
     "traffic",
-    "earthquakes"
+    "earthquakes",
+    "snow"
   ],
   "license": "MIT",
   "compatibility": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vikramgorla/swiss",
   "title": "Switzerland MCP 🇨🇭",
-  "description": "Swiss open data MCP server. 73 tools, zero API keys. Transport, weather, geodata, news, rates.",
+  "description": "Swiss open data MCP server. 76 tools, zero API keys. Transport, weather, geodata, news, rates.",
   "repository": {
     "url": "https://github.com/vikramgorla/mcp-swiss",
     "source": "github"

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { hikingTools, handleHiking } from "./modules/hiking.js";
 import { realEstateTools, handleRealEstate } from "./modules/realestate.js";
 import { trafficTools, handleTraffic } from "./modules/traffic.js";
 import { earthquakeTools, handleEarthquakes } from "./modules/earthquakes.js";
+import { snowTools, handleSnow } from "./modules/snow.js";
 
 // ── Module Registry ──────────────────────────────────────────────────────────
 
@@ -57,13 +58,14 @@ export const moduleRegistry: Record<string, ModuleEntry> = {
   realestate:  { tools: realEstateTools,  handler: handleRealEstate },
   traffic:     { tools: trafficTools,     handler: handleTraffic },
   earthquakes: { tools: earthquakeTools,  handler: handleEarthquakes as ToolHandler },
+  snow:        { tools: snowTools,        handler: handleSnow },
 };
 
 // ── Presets ───────────────────────────────────────────────────────────────────
 
 export const presets: Record<string, string[]> = {
   commuter:  ["transport", "weather", "holidays"],
-  outdoor:   ["weather", "avalanche", "hiking", "earthquakes", "dams"],
+  outdoor:   ["weather", "avalanche", "hiking", "earthquakes", "dams", "snow"],
   business:  ["companies", "geodata", "post", "energy", "statistics", "snb"],
   citizen:   ["parliament", "voting", "holidays", "news"],
   minimal:   ["transport"],

--- a/src/modules/snow.ts
+++ b/src/modules/snow.ts
@@ -1,0 +1,355 @@
+/**
+ * SLF Snow Conditions module
+ *
+ * Data source: WSL Institute for Snow and Avalanche Research SLF (CC BY 4.0)
+ * API: measurement-api.slf.ch/public/api
+ *
+ * Provides:
+ *   - get_snow_conditions: current snow depth + fresh snow across Switzerland
+ *   - list_snow_stations: all SLF snow measurement stations (IMIS + study plots)
+ *   - get_snow_measurements: detailed measurements for a specific station
+ */
+
+import { fetchJSON } from "../utils/http.js";
+
+const BASE = "https://measurement-api.slf.ch/public/api";
+
+// ── API response types ─────────────────────────────────────────────────────
+
+interface ImisStation {
+  code: string;
+  label: string;
+  lon: number;
+  lat: number;
+  elevation: number;
+  country_code: string;
+  canton_code: string;
+  type: string;
+}
+
+interface StudyPlotStation {
+  code: string;
+  label: string;
+  lon: number;
+  lat: number;
+  elevation: number;
+  country_code: string;
+  canton_code: string;
+}
+
+interface DailySnow {
+  station_code: string;
+  measure_date: string;
+  HS: number | null;
+  HN_1D: number | null;
+}
+
+interface ImisMeasurement {
+  station_code: string;
+  measure_date: string;
+  HS: number | null;
+  TA_30MIN_MEAN: number | null;
+  RH_30MIN_MEAN: number | null;
+  TSS_30MIN_MEAN: number | null;
+  TS0_30MIN_MEAN: number | null;
+  TS25_30MIN_MEAN: number | null;
+  TS50_30MIN_MEAN: number | null;
+  TS100_30MIN_MEAN: number | null;
+  RSWR_30MIN_MEAN: number | null;
+  VW_30MIN_MEAN: number | null;
+  VW_30MIN_MAX: number | null;
+  DW_30MIN_MEAN: number | null;
+  DW_30MIN_SD: number | null;
+}
+
+interface StudyPlotMeasurement {
+  station_code: string;
+  measure_date: string;
+  HS: number | null;
+  HN_1D: number | null;
+  HNW_1D: number | null;
+}
+
+// ── Tool definitions ────────────────────────────────────────────────────────
+
+export const snowTools = [
+  {
+    name: "get_snow_conditions",
+    description:
+      "Get current snow conditions across Switzerland from SLF (WSL Institute for Snow and Avalanche Research). " +
+      "Returns snow depth and new snow (24h) for IMIS stations, sorted by snow depth. " +
+      "Filter by canton or minimum altitude. Data updated daily.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        canton: {
+          type: "string",
+          description:
+            "Filter by canton abbreviation (e.g. GR, VS, BE, UR, TI). Optional.",
+        },
+        min_altitude: {
+          type: "number",
+          description:
+            "Minimum station altitude in metres (e.g. 2000). Optional.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of stations to return (default: 20, max: 100).",
+        },
+      },
+    },
+  },
+  {
+    name: "list_snow_stations",
+    description:
+      "List all SLF snow measurement stations in Switzerland (IMIS automatic stations and manual study plots). " +
+      "Returns station code, name, altitude, canton, and type. Sorted by elevation descending.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        canton: {
+          type: "string",
+          description:
+            "Filter by canton abbreviation (e.g. GR, VS, BE). Optional.",
+        },
+        type: {
+          type: "string",
+          enum: ["imis", "study-plot"],
+          description:
+            'Station type: "imis" (automatic) or "study-plot" (manual). Optional — returns both by default.',
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of stations to return (default: 20, max: 200).",
+        },
+      },
+    },
+  },
+  {
+    name: "get_snow_measurements",
+    description:
+      "Get detailed snow and weather measurements for a specific SLF station. " +
+      "IMIS stations return 30-min data (snow depth, temperature, humidity, wind, radiation). " +
+      "Study plots return daily data (snow depth, new snow, water equivalent). " +
+      "Use list_snow_stations to find station codes.",
+    inputSchema: {
+      type: "object",
+      required: ["station_code"],
+      properties: {
+        station_code: {
+          type: "string",
+          description:
+            "Station code (e.g. DAV2, WFJ2, 4AO0). Use list_snow_stations to find codes.",
+        },
+        type: {
+          type: "string",
+          enum: ["imis", "study-plot"],
+          description:
+            'Station type: "imis" (default) or "study-plot". Determines which API endpoint to query.',
+        },
+      },
+    },
+  },
+];
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+async function handleGetSnowConditions(
+  args: Record<string, unknown>
+): Promise<string> {
+  const canton = typeof args.canton === "string" ? args.canton.trim().toUpperCase() : undefined;
+  const minAlt = typeof args.min_altitude === "number" ? args.min_altitude : undefined;
+  const limit = Math.min(Math.max(Number(args.limit) || 20, 1), 100);
+
+  // Fetch snow data and station metadata in parallel
+  const [dailySnow, stations] = await Promise.all([
+    fetchJSON<DailySnow[]>(`${BASE}/imis/daily-snow`),
+    fetchJSON<ImisStation[]>(`${BASE}/imis/stations`),
+  ]);
+
+  // Build station lookup
+  const stationMap = new Map<string, ImisStation>();
+  for (const s of stations) {
+    stationMap.set(s.code, s);
+  }
+
+  // Join, filter, sort
+  const joined = dailySnow
+    .map((d) => {
+      const s = stationMap.get(d.station_code);
+      if (!s) return null;
+      return {
+        station: s.label,
+        code: s.code,
+        altitude_m: s.elevation,
+        canton: s.canton_code,
+        snow_depth_cm: d.HS,
+        new_snow_24h_cm: d.HN_1D,
+        date: d.measure_date?.slice(0, 10) ?? null,
+      };
+    })
+    .filter((r): r is NonNullable<typeof r> => {
+      if (!r) return false;
+      if (canton && r.canton !== canton) return false;
+      if (minAlt !== undefined && r.altitude_m < minAlt) return false;
+      return true;
+    })
+    .sort((a, b) => (b.snow_depth_cm ?? 0) - (a.snow_depth_cm ?? 0))
+    .slice(0, limit);
+
+  return JSON.stringify({
+    count: joined.length,
+    filters: {
+      ...(canton ? { canton } : {}),
+      ...(minAlt !== undefined ? { min_altitude_m: minAlt } : {}),
+    },
+    stations: joined,
+    source: "WSL Institute for Snow and Avalanche Research SLF (CC BY 4.0)",
+  });
+}
+
+async function handleListSnowStations(
+  args: Record<string, unknown>
+): Promise<string> {
+  const canton = typeof args.canton === "string" ? args.canton.trim().toUpperCase() : undefined;
+  const typeFilter = typeof args.type === "string" ? args.type.trim().toLowerCase() : undefined;
+  const limit = Math.min(Math.max(Number(args.limit) || 20, 1), 200);
+
+  // Fetch station lists (conditionally based on type filter)
+  const fetchImis = !typeFilter || typeFilter === "imis";
+  const fetchStudy = !typeFilter || typeFilter === "study-plot";
+
+  const [imisStations, studyStations] = await Promise.all([
+    fetchImis ? fetchJSON<ImisStation[]>(`${BASE}/imis/stations`) : Promise.resolve([]),
+    fetchStudy ? fetchJSON<StudyPlotStation[]>(`${BASE}/study-plot/stations`) : Promise.resolve([]),
+  ]);
+
+  type StationEntry = {
+    code: string;
+    name: string;
+    altitude_m: number;
+    canton: string;
+    type: string;
+  };
+
+  const combined: StationEntry[] = [
+    ...imisStations.map((s) => ({
+      code: s.code,
+      name: s.label,
+      altitude_m: s.elevation,
+      canton: s.canton_code,
+      type: "imis" as const,
+    })),
+    ...studyStations.map((s) => ({
+      code: s.code,
+      name: s.label,
+      altitude_m: s.elevation,
+      canton: s.canton_code,
+      type: "study-plot" as const,
+    })),
+  ];
+
+  const filtered = combined
+    .filter((s) => !canton || s.canton === canton)
+    .sort((a, b) => b.altitude_m - a.altitude_m)
+    .slice(0, limit);
+
+  return JSON.stringify({
+    count: filtered.length,
+    total_stations: combined.length,
+    ...(canton ? { canton } : {}),
+    ...(typeFilter ? { type: typeFilter } : {}),
+    stations: filtered,
+    source: "WSL Institute for Snow and Avalanche Research SLF (CC BY 4.0)",
+  });
+}
+
+async function handleGetSnowMeasurements(
+  args: Record<string, unknown>
+): Promise<string> {
+  const stationCode = args.station_code;
+  if (typeof stationCode !== "string" || !stationCode.trim()) {
+    throw new Error("station_code is required");
+  }
+  const code = stationCode.trim();
+  const stationType =
+    typeof args.type === "string" && args.type.trim().toLowerCase() === "study-plot"
+      ? "study-plot"
+      : "imis";
+
+  if (stationType === "study-plot") {
+    const measurements = await fetchJSON<StudyPlotMeasurement[]>(
+      `${BASE}/study-plot/station/${encodeURIComponent(code)}/measurements`
+    );
+
+    const latest = measurements.slice(-10).reverse().map((m) => ({
+      time: m.measure_date,
+      snow_depth_cm: m.HS,
+      new_snow_24h_cm: m.HN_1D,
+      new_snow_water_equiv_mm: m.HNW_1D,
+    }));
+
+    return JSON.stringify({
+      station_code: code,
+      type: "study-plot",
+      measurement_count: latest.length,
+      measurements: latest,
+      source: "WSL Institute for Snow and Avalanche Research SLF (CC BY 4.0)",
+    });
+  }
+
+  // IMIS station
+  const measurements = await fetchJSON<ImisMeasurement[]>(
+    `${BASE}/imis/station/${encodeURIComponent(code)}/measurements`
+  );
+
+  // Return latest 10 measurements, most recent first, with readable field names
+  const latest = measurements.slice(-10).reverse().map((m) => ({
+    time: m.measure_date,
+    snow_depth_cm: m.HS,
+    air_temp_c: m.TA_30MIN_MEAN,
+    humidity_pct: m.RH_30MIN_MEAN,
+    surface_temp_c: m.TSS_30MIN_MEAN,
+    ground_temp_0cm_c: m.TS0_30MIN_MEAN,
+    reflected_radiation_w_m2: m.RSWR_30MIN_MEAN,
+    wind_speed_m_s: m.VW_30MIN_MEAN,
+    wind_gust_m_s: m.VW_30MIN_MAX,
+    wind_direction_deg: m.DW_30MIN_MEAN,
+  }));
+
+  return JSON.stringify({
+    station_code: code,
+    type: "imis",
+    measurement_count: latest.length,
+    measurements: latest,
+    fields: {
+      snow_depth_cm: "Total snow depth (HS)",
+      air_temp_c: "Air temperature 30-min mean",
+      humidity_pct: "Relative humidity 30-min mean",
+      surface_temp_c: "Snow surface temperature",
+      reflected_radiation_w_m2: "Reflected shortwave radiation",
+      wind_speed_m_s: "Wind speed 30-min mean",
+      wind_gust_m_s: "Wind gust 30-min max",
+      wind_direction_deg: "Wind direction 30-min mean",
+    },
+    source: "WSL Institute for Snow and Avalanche Research SLF (CC BY 4.0)",
+  });
+}
+
+// ── Main dispatcher ─────────────────────────────────────────────────────────
+
+export async function handleSnow(
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  switch (name) {
+    case "get_snow_conditions":
+      return handleGetSnowConditions(args);
+    case "list_snow_stations":
+      return handleListSnowStations(args);
+    case "get_snow_measurements":
+      return handleGetSnowMeasurements(args);
+    default:
+      throw new Error(`Unknown snow tool: ${name}`);
+  }
+}

--- a/tests/fixtures/snow.ts
+++ b/tests/fixtures/snow.ts
@@ -1,0 +1,219 @@
+/**
+ * Mock API responses for snow module tests.
+ */
+
+// ── IMIS stations ───────────────────────────────────────────────────────────
+
+export const mockImisStations = [
+  {
+    code: "DAV2",
+    label: "Bärentälli",
+    lon: 9.8194,
+    lat: 46.6989,
+    elevation: 2558.0,
+    country_code: "CH",
+    canton_code: "GR",
+    type: "SNOW_FLAT",
+  },
+  {
+    code: "WFJ2",
+    label: "Weissfluhjoch",
+    lon: 9.8064,
+    lat: 46.8297,
+    elevation: 2536.0,
+    country_code: "CH",
+    canton_code: "GR",
+    type: "SNOW_FLAT",
+  },
+  {
+    code: "ZER4",
+    label: "Zermatt",
+    lon: 7.7498,
+    lat: 46.0297,
+    elevation: 3150.0,
+    country_code: "CH",
+    canton_code: "VS",
+    type: "SNOW_FLAT",
+  },
+  {
+    code: "ELM2",
+    label: "Elm",
+    lon: 9.1741,
+    lat: 46.9171,
+    elevation: 1480.0,
+    country_code: "CH",
+    canton_code: "GL",
+    type: "SNOW_FLAT",
+  },
+  {
+    code: "AND2",
+    label: "Andermatt",
+    lon: 8.5946,
+    lat: 46.6381,
+    elevation: 2106.0,
+    country_code: "CH",
+    canton_code: "UR",
+    type: "SNOW_FLAT",
+  },
+];
+
+// ── Study plot stations ─────────────────────────────────────────────────────
+
+export const mockStudyPlotStations = [
+  {
+    code: "4AO0",
+    label: "Arolla",
+    lon: 7.4803,
+    lat: 46.0281,
+    elevation: 2070.0,
+    country_code: "CH",
+    canton_code: "VS",
+  },
+  {
+    code: "1AD0",
+    label: "Adelboden",
+    lon: 7.5647,
+    lat: 46.4932,
+    elevation: 1350.0,
+    country_code: "CH",
+    canton_code: "BE",
+  },
+  {
+    code: "2DA0",
+    label: "Davos",
+    lon: 9.8513,
+    lat: 46.8130,
+    elevation: 1560.0,
+    country_code: "CH",
+    canton_code: "GR",
+  },
+];
+
+// ── Daily snow data ─────────────────────────────────────────────────────────
+
+export const mockDailySnow = [
+  {
+    station_code: "ZER4",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 245.0,
+    HN_1D: 32.0,
+  },
+  {
+    station_code: "DAV2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 139.0,
+    HN_1D: 15.2,
+  },
+  {
+    station_code: "WFJ2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 198.0,
+    HN_1D: 22.5,
+  },
+  {
+    station_code: "ELM2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 55.0,
+    HN_1D: 5.0,
+  },
+  {
+    station_code: "AND2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 170.0,
+    HN_1D: 18.0,
+  },
+];
+
+// Daily snow with null values
+export const mockDailySnowWithNulls = [
+  {
+    station_code: "DAV2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: null,
+    HN_1D: null,
+  },
+  {
+    station_code: "WFJ2",
+    measure_date: "2026-03-15T00:00:00",
+    HS: 198.0,
+    HN_1D: null,
+  },
+];
+
+// ── IMIS measurements (detailed 30-min data) ───────────────────────────────
+
+export const mockImisMeasurements = [
+  {
+    station_code: "DAV2",
+    measure_date: "2026-03-15T07:30:00Z",
+    HS: 138.5,
+    TA_30MIN_MEAN: -8.2,
+    RH_30MIN_MEAN: 91.5,
+    TSS_30MIN_MEAN: -12.3,
+    TS0_30MIN_MEAN: 0.7,
+    TS25_30MIN_MEAN: -0.4,
+    TS50_30MIN_MEAN: -1.5,
+    TS100_30MIN_MEAN: -3.1,
+    RSWR_30MIN_MEAN: 120.0,
+    VW_30MIN_MEAN: 2.5,
+    VW_30MIN_MAX: 6.8,
+    DW_30MIN_MEAN: 180.0,
+    DW_30MIN_SD: 22.0,
+  },
+  {
+    station_code: "DAV2",
+    measure_date: "2026-03-15T08:00:00Z",
+    HS: 139.0,
+    TA_30MIN_MEAN: -7.5,
+    RH_30MIN_MEAN: 89.2,
+    TSS_30MIN_MEAN: -11.8,
+    TS0_30MIN_MEAN: 0.7,
+    TS25_30MIN_MEAN: -0.3,
+    TS50_30MIN_MEAN: -1.4,
+    TS100_30MIN_MEAN: -3.0,
+    RSWR_30MIN_MEAN: 250.0,
+    VW_30MIN_MEAN: 3.1,
+    VW_30MIN_MAX: 8.2,
+    DW_30MIN_MEAN: 175.0,
+    DW_30MIN_SD: 18.0,
+  },
+  {
+    station_code: "DAV2",
+    measure_date: "2026-03-15T08:30:00Z",
+    HS: 139.2,
+    TA_30MIN_MEAN: -6.8,
+    RH_30MIN_MEAN: 87.0,
+    TSS_30MIN_MEAN: -11.0,
+    TS0_30MIN_MEAN: 0.7,
+    TS25_30MIN_MEAN: -0.3,
+    TS50_30MIN_MEAN: -1.4,
+    TS100_30MIN_MEAN: -2.9,
+    RSWR_30MIN_MEAN: 400.0,
+    VW_30MIN_MEAN: 1.8,
+    VW_30MIN_MAX: 4.5,
+    DW_30MIN_MEAN: 165.0,
+    DW_30MIN_SD: 15.0,
+  },
+];
+
+// ── Study plot measurements ─────────────────────────────────────────────────
+
+export const mockStudyPlotMeasurements = [
+  {
+    station_code: "4AO0",
+    measure_date: "2026-03-15T06:00:00Z",
+    HS: 79.0,
+    HN_1D: 21.0,
+    HNW_1D: null,
+  },
+  {
+    station_code: "4AO0",
+    measure_date: "2026-03-14T06:00:00Z",
+    HS: 65.0,
+    HN_1D: 8.0,
+    HNW_1D: 5.2,
+  },
+];
+
+// Empty responses
+export const mockEmptyArray: unknown[] = [];

--- a/tests/integration/energy.integration.test.ts
+++ b/tests/integration/energy.integration.test.ts
@@ -32,7 +32,7 @@ describe('ElCom Energy API (live)', () => {
     }, TIMEOUT);
 
     it('finds Geneva (Genève)', async () => {
-      const result = JSON.parse(await handleEnergy('search_municipality_energy', { name: 'Gen' }));
+      const result = JSON.parse(await handleEnergy('search_municipality_energy', { name: 'Genève' }));
       expect(result.results.length).toBeGreaterThan(0);
       const geneve = result.results.find((m: { id: string }) => m.id === '6621');
       expect(geneve).toBeTruthy();

--- a/tests/integration/snow.integration.test.ts
+++ b/tests/integration/snow.integration.test.ts
@@ -1,0 +1,145 @@
+// These tests hit the real SLF API — run with: npm run test:integration
+import { describe, it, expect } from "vitest";
+import { handleSnow } from "../../src/modules/snow.js";
+
+describe("Snow API (live — SLF/WSL)", () => {
+  // ── get_snow_conditions ─────────────────────────────────────────────────
+
+  it("get_snow_conditions returns stations with snow data", async () => {
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    expect(result.count).toBeGreaterThan(0);
+    expect(Array.isArray(result.stations)).toBe(true);
+    expect(result.source).toContain("SLF");
+  });
+
+  it("snow conditions have expected shape", async () => {
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { limit: 5 })
+    );
+    expect(result.stations.length).toBeGreaterThan(0);
+    const s = result.stations[0];
+    expect(typeof s.station).toBe("string");
+    expect(typeof s.code).toBe("string");
+    expect(typeof s.altitude_m).toBe("number");
+    expect(typeof s.canton).toBe("string");
+    // HS can be null if no snow
+    expect(s.snow_depth_cm === null || typeof s.snow_depth_cm === "number").toBe(true);
+    expect(s.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("snow conditions filtered by canton GR", async () => {
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { canton: "GR", limit: 50 })
+    );
+    for (const s of result.stations) {
+      expect(s.canton).toBe("GR");
+    }
+  });
+
+  it("snow conditions filtered by min_altitude", async () => {
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { min_altitude: 2500, limit: 50 })
+    );
+    for (const s of result.stations) {
+      expect(s.altitude_m).toBeGreaterThanOrEqual(2500);
+    }
+  });
+
+  it("snow conditions response is under 50K chars", async () => {
+    const raw = await handleSnow("get_snow_conditions", { limit: 100 });
+    expect(raw.length).toBeLessThan(50000);
+  });
+
+  // ── list_snow_stations ──────────────────────────────────────────────────
+
+  it("list_snow_stations returns stations", async () => {
+    const result = JSON.parse(await handleSnow("list_snow_stations", { limit: 50 }));
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.total_stations).toBeGreaterThan(200); // 207 IMIS + 100 study = 307
+    expect(result.source).toContain("SLF");
+  });
+
+  it("stations have expected shape", async () => {
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { limit: 5 })
+    );
+    const s = result.stations[0];
+    expect(typeof s.code).toBe("string");
+    expect(typeof s.name).toBe("string");
+    expect(typeof s.altitude_m).toBe("number");
+    expect(typeof s.canton).toBe("string");
+    expect(["imis", "study-plot"]).toContain(s.type);
+  });
+
+  it("filters by type=imis", async () => {
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { type: "imis", limit: 50 })
+    );
+    for (const s of result.stations) {
+      expect(s.type).toBe("imis");
+    }
+  });
+
+  it("filters by type=study-plot", async () => {
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { type: "study-plot", limit: 50 })
+    );
+    for (const s of result.stations) {
+      expect(s.type).toBe("study-plot");
+    }
+  });
+
+  it("list_snow_stations response is under 50K chars", async () => {
+    const raw = await handleSnow("list_snow_stations", { limit: 200 });
+    expect(raw.length).toBeLessThan(50000);
+  });
+
+  // ── get_snow_measurements ───────────────────────────────────────────────
+
+  it("get_snow_measurements returns IMIS data for DAV2", async () => {
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    expect(result.station_code).toBe("DAV2");
+    expect(result.type).toBe("imis");
+    expect(result.measurement_count).toBeGreaterThan(0);
+    expect(Array.isArray(result.measurements)).toBe(true);
+  });
+
+  it("IMIS measurements have weather fields", async () => {
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    const m = result.measurements[0];
+    expect(m.time).toBeDefined();
+    expect(m.snow_depth_cm === null || typeof m.snow_depth_cm === "number").toBe(true);
+    expect(m.air_temp_c === null || typeof m.air_temp_c === "number").toBe(true);
+  });
+
+  it("get_snow_measurements returns study-plot data", async () => {
+    // First get a study plot station code
+    const stations = JSON.parse(
+      await handleSnow("list_snow_stations", { type: "study-plot", limit: 1 })
+    );
+    if (stations.count === 0) {
+      console.log("No study-plot stations — skipping");
+      return;
+    }
+    const code = stations.stations[0].code;
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", {
+        station_code: code,
+        type: "study-plot",
+      })
+    );
+    expect(result.station_code).toBe(code);
+    expect(result.type).toBe("study-plot");
+  });
+
+  it("measurements response is under 50K chars", async () => {
+    const raw = await handleSnow("get_snow_measurements", {
+      station_code: "DAV2",
+    });
+    expect(raw.length).toBeLessThan(50000);
+  });
+});

--- a/tests/mcp/protocol.test.ts
+++ b/tests/mcp/protocol.test.ts
@@ -120,7 +120,7 @@ describe('MCP protocol: tools/list', () => {
     expect(Array.isArray(result.tools)).toBe(true);
   });
 
-  it('returns exactly 73 tools', async () => {
+  it('returns exactly 76 tools', async () => {
     const response = await sendMcpRequest({
       jsonrpc: '2.0',
       id: 3,
@@ -128,7 +128,7 @@ describe('MCP protocol: tools/list', () => {
     });
 
     const result = response.result as { tools: Tool[] };
-    expect(result.tools).toHaveLength(73);
+    expect(result.tools).toHaveLength(76);
   });
 
   it('each tool has name, description, inputSchema', async () => {

--- a/tests/unit/module-filtering.test.ts
+++ b/tests/unit/module-filtering.test.ts
@@ -9,8 +9,8 @@ import {
 // ── Module Registry ──────────────────────────────────────────────────────────
 
 describe("Module Registry", () => {
-  it("should have all 20 modules", () => {
-    expect(Object.keys(moduleRegistry)).toHaveLength(20);
+  it("should have all 21 modules", () => {
+    expect(Object.keys(moduleRegistry)).toHaveLength(21);
   });
 
   it("should contain every expected module name", () => {
@@ -35,6 +35,7 @@ describe("Module Registry", () => {
       "realestate",
       "traffic",
       "earthquakes",
+      "snow",
     ];
     for (const name of expected) {
       expect(moduleRegistry).toHaveProperty(name);
@@ -53,12 +54,12 @@ describe("Module Registry", () => {
     }
   });
 
-  it("total tool count should be 73", () => {
+  it("total tool count should be 76", () => {
     const total = Object.values(moduleRegistry).reduce(
       (sum, m) => sum + m.tools.length,
       0
     );
-    expect(total).toBe(73);
+    expect(total).toBe(76);
   });
 });
 
@@ -73,13 +74,14 @@ describe("Presets", () => {
     expect(presets.commuter).toEqual(["transport", "weather", "holidays"]);
   });
 
-  it("outdoor should have weather, avalanche, hiking, earthquakes, dams", () => {
+  it("outdoor should have weather, avalanche, hiking, earthquakes, dams, snow", () => {
     expect(presets.outdoor).toEqual([
       "weather",
       "avalanche",
       "hiking",
       "earthquakes",
       "dams",
+      "snow",
     ]);
   });
 
@@ -107,8 +109,8 @@ describe("Presets", () => {
     expect(presets.minimal).toEqual(["transport"]);
   });
 
-  it("full should have all 20 modules", () => {
-    expect(presets.full).toHaveLength(20);
+  it("full should have all 21 modules", () => {
+    expect(presets.full).toHaveLength(21);
     expect(new Set(presets.full)).toEqual(
       new Set(Object.keys(moduleRegistry))
     );
@@ -217,7 +219,7 @@ describe("CLI Arguments — parseArgs()", () => {
 describe("resolveModules()", () => {
   it("should return all modules when null is passed", () => {
     const active = resolveModules(null);
-    expect(active).toHaveLength(20);
+    expect(active).toHaveLength(21);
     expect(active.map((m) => m.name)).toEqual(Object.keys(moduleRegistry));
   });
 

--- a/tests/unit/snow.test.ts
+++ b/tests/unit/snow.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { handleSnow, snowTools } from "../../src/modules/snow.js";
+import {
+  mockImisStations,
+  mockStudyPlotStations,
+  mockDailySnow,
+  mockDailySnowWithNulls,
+  mockImisMeasurements,
+  mockStudyPlotMeasurements,
+  mockEmptyArray,
+} from "../fixtures/snow.js";
+
+// ── Fetch mock helpers ────────────────────────────────────────────────────────
+
+function mockFetchJSON(...responses: unknown[]) {
+  let callIndex = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(() => {
+      const data = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: () => Promise.resolve(data),
+      });
+    })
+  );
+}
+
+function mockFetchError(status = 500) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({}),
+    })
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── Tool definitions ──────────────────────────────────────────────────────────
+
+describe("snowTools", () => {
+  it("exports 3 tools", () => {
+    expect(snowTools).toHaveLength(3);
+  });
+
+  it("tool names are correct", () => {
+    const names = snowTools.map((t) => t.name);
+    expect(names).toContain("get_snow_conditions");
+    expect(names).toContain("list_snow_stations");
+    expect(names).toContain("get_snow_measurements");
+  });
+
+  it("get_snow_measurements requires station_code", () => {
+    const tool = snowTools.find((t) => t.name === "get_snow_measurements")!;
+    expect(tool.inputSchema.required).toContain("station_code");
+  });
+
+  it("get_snow_conditions has no required fields", () => {
+    const tool = snowTools.find((t) => t.name === "get_snow_conditions")!;
+    expect(tool.inputSchema.required ?? []).toHaveLength(0);
+  });
+
+  it("list_snow_stations has no required fields", () => {
+    const tool = snowTools.find((t) => t.name === "list_snow_stations")!;
+    expect(tool.inputSchema.required ?? []).toHaveLength(0);
+  });
+});
+
+// ── get_snow_conditions ───────────────────────────────────────────────────────
+
+describe("get_snow_conditions", () => {
+  it("returns stations sorted by snow depth descending", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    expect(result.count).toBe(5);
+    expect(result.stations[0].code).toBe("ZER4"); // 245 cm
+    expect(result.stations[1].code).toBe("WFJ2"); // 198 cm
+    expect(result.stations[2].code).toBe("AND2"); // 170 cm
+  });
+
+  it("each station has expected fields", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    const s = result.stations[0];
+    expect(s.station).toBe("Zermatt");
+    expect(typeof s.altitude_m).toBe("number");
+    expect(typeof s.canton).toBe("string");
+    expect(typeof s.snow_depth_cm).toBe("number");
+    expect(typeof s.new_snow_24h_cm).toBe("number");
+    expect(s.date).toBe("2026-03-15");
+  });
+
+  it("filters by canton", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { canton: "GR" })
+    );
+    expect(result.count).toBe(2); // DAV2 + WFJ2
+    expect(result.filters.canton).toBe("GR");
+    for (const s of result.stations) {
+      expect(s.canton).toBe("GR");
+    }
+  });
+
+  it("filters by min_altitude", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { min_altitude: 2500 })
+    );
+    // ZER4 (3150), DAV2 (2558), WFJ2 (2536) — all >= 2500
+    expect(result.count).toBe(3);
+    expect(result.filters.min_altitude_m).toBe(2500);
+    for (const s of result.stations) {
+      expect(s.altitude_m).toBeGreaterThanOrEqual(2500);
+    }
+  });
+
+  it("combines canton and min_altitude filters", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { canton: "GR", min_altitude: 2550 })
+    );
+    expect(result.count).toBe(1); // Only DAV2 (2558, GR)
+    expect(result.stations[0].code).toBe("DAV2");
+  });
+
+  it("respects limit parameter", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { limit: 2 })
+    );
+    expect(result.count).toBe(2);
+  });
+
+  it("caps limit at 100", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { limit: 999 })
+    );
+    // All 5 returned (< 100)
+    expect(result.count).toBe(5);
+  });
+
+  it("handles null HS/HN_1D values", async () => {
+    mockFetchJSON(mockDailySnowWithNulls, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    expect(result.count).toBe(2);
+    // Station with null HS sorts after station with 198
+    expect(result.stations[0].snow_depth_cm).toBe(198.0);
+    expect(result.stations[1].snow_depth_cm).toBeNull();
+  });
+
+  it("handles empty snow data", async () => {
+    mockFetchJSON(mockEmptyArray, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    expect(result.count).toBe(0);
+    expect(result.stations).toHaveLength(0);
+  });
+
+  it("skips stations not found in station map", async () => {
+    const snowWithUnknown = [
+      ...mockDailySnow,
+      { station_code: "UNKNOWN", measure_date: "2026-03-15T00:00:00", HS: 500, HN_1D: 50 },
+    ];
+    mockFetchJSON(snowWithUnknown, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    // UNKNOWN station should be filtered out
+    expect(result.count).toBe(5);
+  });
+
+  it("canton filter is case-insensitive", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(
+      await handleSnow("get_snow_conditions", { canton: "gr" })
+    );
+    expect(result.count).toBe(2);
+  });
+
+  it("contains source attribution", async () => {
+    mockFetchJSON(mockDailySnow, mockImisStations);
+    const result = JSON.parse(await handleSnow("get_snow_conditions", {}));
+    expect(result.source).toContain("SLF");
+  });
+
+  it("throws on HTTP error", async () => {
+    mockFetchError(500);
+    await expect(handleSnow("get_snow_conditions", {})).rejects.toThrow(
+      "HTTP 500"
+    );
+  });
+});
+
+// ── list_snow_stations ────────────────────────────────────────────────────────
+
+describe("list_snow_stations", () => {
+  it("returns combined IMIS and study-plot stations", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(await handleSnow("list_snow_stations", {}));
+    expect(result.total_stations).toBe(8); // 5 + 3
+    expect(result.count).toBeLessThanOrEqual(20);
+  });
+
+  it("stations are sorted by elevation descending", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(await handleSnow("list_snow_stations", { limit: 100 }));
+    const altitudes = result.stations.map((s: { altitude_m: number }) => s.altitude_m);
+    for (let i = 1; i < altitudes.length; i++) {
+      expect(altitudes[i]).toBeLessThanOrEqual(altitudes[i - 1]);
+    }
+  });
+
+  it("each station has expected fields", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(await handleSnow("list_snow_stations", { limit: 100 }));
+    for (const s of result.stations) {
+      expect(typeof s.code).toBe("string");
+      expect(typeof s.name).toBe("string");
+      expect(typeof s.altitude_m).toBe("number");
+      expect(typeof s.canton).toBe("string");
+      expect(["imis", "study-plot"]).toContain(s.type);
+    }
+  });
+
+  it("filters by type=imis", async () => {
+    mockFetchJSON(mockImisStations, mockEmptyArray);
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { type: "imis", limit: 100 })
+    );
+    expect(result.type).toBe("imis");
+    for (const s of result.stations) {
+      expect(s.type).toBe("imis");
+    }
+  });
+
+  it("filters by type=study-plot", async () => {
+    mockFetchJSON(mockEmptyArray, mockStudyPlotStations);
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { type: "study-plot", limit: 100 })
+    );
+    expect(result.type).toBe("study-plot");
+    for (const s of result.stations) {
+      expect(s.type).toBe("study-plot");
+    }
+  });
+
+  it("filters by canton", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { canton: "VS", limit: 100 })
+    );
+    expect(result.canton).toBe("VS");
+    for (const s of result.stations) {
+      expect(s.canton).toBe("VS");
+    }
+  });
+
+  it("respects limit", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { limit: 3 })
+    );
+    expect(result.count).toBe(3);
+    expect(result.stations).toHaveLength(3);
+  });
+
+  it("caps limit at 200", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(
+      await handleSnow("list_snow_stations", { limit: 999 })
+    );
+    expect(result.count).toBe(8);
+  });
+
+  it("handles empty station lists", async () => {
+    mockFetchJSON(mockEmptyArray, mockEmptyArray);
+    const result = JSON.parse(await handleSnow("list_snow_stations", {}));
+    expect(result.count).toBe(0);
+    expect(result.total_stations).toBe(0);
+  });
+
+  it("contains source attribution", async () => {
+    mockFetchJSON(mockImisStations, mockStudyPlotStations);
+    const result = JSON.parse(await handleSnow("list_snow_stations", {}));
+    expect(result.source).toContain("SLF");
+  });
+
+  it("throws on HTTP error", async () => {
+    mockFetchError(503);
+    await expect(handleSnow("list_snow_stations", {})).rejects.toThrow(
+      "HTTP 503"
+    );
+  });
+});
+
+// ── get_snow_measurements ─────────────────────────────────────────────────────
+
+describe("get_snow_measurements", () => {
+  it("returns IMIS measurements by default", async () => {
+    mockFetchJSON(mockImisMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    expect(result.station_code).toBe("DAV2");
+    expect(result.type).toBe("imis");
+    expect(result.measurement_count).toBe(3);
+    expect(Array.isArray(result.measurements)).toBe(true);
+  });
+
+  it("IMIS measurements have readable field names", async () => {
+    mockFetchJSON(mockImisMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    const m = result.measurements[0]; // most recent (reversed)
+    expect(m.time).toBeDefined();
+    expect(typeof m.snow_depth_cm).toBe("number");
+    expect(typeof m.air_temp_c).toBe("number");
+    expect(typeof m.humidity_pct).toBe("number");
+    expect(typeof m.wind_speed_m_s).toBe("number");
+  });
+
+  it("measurements are returned most-recent-first", async () => {
+    mockFetchJSON(mockImisMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    const times = result.measurements.map((m: { time: string }) => m.time);
+    // First should be latest (08:30), last should be earliest (07:30)
+    expect(times[0]).toBe("2026-03-15T08:30:00Z");
+    expect(times[times.length - 1]).toBe("2026-03-15T07:30:00Z");
+  });
+
+  it("IMIS result includes field descriptions", async () => {
+    mockFetchJSON(mockImisMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    expect(result.fields).toBeDefined();
+    expect(result.fields.snow_depth_cm).toContain("snow depth");
+  });
+
+  it("returns study-plot measurements when type=study-plot", async () => {
+    mockFetchJSON(mockStudyPlotMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", {
+        station_code: "4AO0",
+        type: "study-plot",
+      })
+    );
+    expect(result.station_code).toBe("4AO0");
+    expect(result.type).toBe("study-plot");
+    expect(result.measurement_count).toBe(2);
+  });
+
+  it("study-plot measurements have correct fields", async () => {
+    mockFetchJSON(mockStudyPlotMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", {
+        station_code: "4AO0",
+        type: "study-plot",
+      })
+    );
+    const m = result.measurements[0];
+    expect(m.time).toBeDefined();
+    expect(typeof m.snow_depth_cm).toBe("number");
+    expect(m).toHaveProperty("new_snow_24h_cm");
+    expect(m).toHaveProperty("new_snow_water_equiv_mm");
+  });
+
+  it("throws when station_code is missing", async () => {
+    await expect(handleSnow("get_snow_measurements", {})).rejects.toThrow(
+      "station_code is required"
+    );
+  });
+
+  it("throws when station_code is empty", async () => {
+    await expect(
+      handleSnow("get_snow_measurements", { station_code: "  " })
+    ).rejects.toThrow("station_code is required");
+  });
+
+  it("handles empty measurement response", async () => {
+    mockFetchJSON(mockEmptyArray);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    expect(result.measurement_count).toBe(0);
+    expect(result.measurements).toHaveLength(0);
+  });
+
+  it("contains source attribution", async () => {
+    mockFetchJSON(mockImisMeasurements);
+    const result = JSON.parse(
+      await handleSnow("get_snow_measurements", { station_code: "DAV2" })
+    );
+    expect(result.source).toContain("SLF");
+  });
+
+  it("throws on HTTP error", async () => {
+    mockFetchError(404);
+    await expect(
+      handleSnow("get_snow_measurements", { station_code: "BADCODE" })
+    ).rejects.toThrow("HTTP 404");
+  });
+});
+
+// ── Unknown tool ──────────────────────────────────────────────────────────────
+
+describe("unknown snow tool", () => {
+  it("throws for unrecognized tool name", async () => {
+    await expect(handleSnow("does_not_exist", {})).rejects.toThrow(
+      "Unknown snow tool: does_not_exist"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new **snow** module with 3 tools for querying live snow conditions from the WSL Institute for Snow and Avalanche Research (SLF).

### New Tools
- **`get_snow_conditions`** — Current snow depth + fresh snow across Switzerland (filterable by canton/altitude)
- **`list_snow_stations`** — All 307 SLF stations (207 IMIS automatic + 100 manual study plots)
- **`get_snow_measurements`** — Detailed 30-min measurements (IMIS) or daily data (study plots) for a specific station

### Data Source
- **API:** `measurement-api.slf.ch/public/api` (no auth required)
- **License:** CC BY 4.0
- **Provider:** WSL Institute for Snow and Avalanche Research SLF

### Changes
- `src/modules/snow.ts` — New module implementation
- `src/index.ts` — Added snow to moduleRegistry + outdoor preset
- `tests/unit/snow.test.ts` — 41 unit tests with mocked API responses
- `tests/fixtures/snow.ts` — Test fixtures
- `tests/integration/snow.integration.test.ts` — Integration tests with live API
- `tests/mcp/protocol.test.ts` — Tool count: 73 → 76
- `tests/unit/module-filtering.test.ts` — Module count: 20 → 21
- `README.md` — Added Snow section, updated counts (76 tools, 21 modules)
- `docs/tool-specs.md` — Snow tool specifications
- `docs/tools.schema.json` — Machine-readable snow tool schemas
- `server.json` — Updated tool count in description
- `manifest.json` — Updated descriptions, keywords, tool list

### Checklist
- [x] lint + build + unit tests pass (937 tests)
- [x] New tools wired in index.ts + protocol test count updated
- [x] README, tool-specs.md, tools.schema.json, server.json updated
- [x] Integration tests with size assertions (<50K)
- [x] No `any` types

Closes #114